### PR TITLE
fix: the laggy issue when scrolling at a large folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,8 @@ If you want, for exemple, to enable relative numbers as well as to show the moti
 add the following to `init.lua`:
 
 ```lua
-require("relative-motions"):setup({show_numbers="relative", show_motion = true})
+require("relative-motions"):setup({ show_numbers="relative", show_motion = true })
 ```
-
-> [!WARNING]
-> The `absolute` and `relative_absolute` option for `show_numbers` might make the scrolling feel
-> laggy, if this happens you should use `relative` or `none`.
 
 > [!NOTE]
 > The `show_numbers` and `show_motion` functionalities overwrite [`Current:render`](https://github.com/sxyazi/yazi/blob/e51e8ad789914b2ab4a9485da7aa7fbc7b3bb450/yazi-plugin/preset/components/current.lua#L5)

--- a/init.lua
+++ b/init.lua
@@ -1,24 +1,24 @@
 -- stylua: ignore
 local MOTIONS_AND_OP_KEYS = {
-	{ on = "0"}, { on = "1"}, { on = "2"}, { on = "3"}, { on = "4"},
-	{ on = "5"}, { on = "6"}, { on = "7"}, { on = "8"}, { on = "9"},
+	{ on = "0" }, { on = "1" }, { on = "2" }, { on = "3" }, { on = "4" },
+	{ on = "5" }, { on = "6" }, { on = "7" }, { on = "8" }, { on = "9" },
 	-- commands
-	{ on = "d"}, { on = "v"}, { on = "y"}, { on = "x"},
+	{ on = "d" }, { on = "v" }, { on = "y" }, { on = "x" },
 	-- movement
-	{ on = "g"}, { on = "j"}, { on = "k"}
+	{ on = "g" }, { on = "j" }, { on = "k" }
 }
 
 -- stylua: ignore
 local MOTION_KEYS = {
-	{ on = "0"}, { on = "1"}, { on = "2"}, { on = "3"}, { on = "4"},
-	{ on = "5"}, { on = "6"}, { on = "7"}, { on = "8"}, { on = "9"},
+	{ on = "0" }, { on = "1" }, { on = "2" }, { on = "3" }, { on = "4" },
+	{ on = "5" }, { on = "6" }, { on = "7" }, { on = "8" }, { on = "9" },
 	-- movement
-	{ on = "g"}, { on = "j"}, { on = "k"}
+	{ on = "g" }, { on = "j" }, { on = "k" }
 }
 
 -- stylua: ignore
 local DIRECTION_KEYS = {
-	{ on = "j"}, { on = "k"}
+	{ on = "j" }, { on = "k" }
 }
 
 local SHOW_NUMBERS_ABSOLUTE = 0
@@ -32,15 +32,13 @@ local SHOW_NUMBERS_RELATIVE_ABSOLUTE = 2
 local render_motion_setup = ya.sync(function()
 	ya.render()
 
-	Status.motion = function()
-		return ui.Span("")
-	end
+	Status.motion = function() return ui.Span("") end
 
 	Status.render = function(self, area)
 		self.area = area
 
-		local left = ui.Line({ self:mode(), self:size(), self:name() })
-		local right = ui.Line({ self:motion(), self:permissions(), self:percentage(), self:position() })
+		local left = ui.Line { self:mode(), self:size(), self:name() }
+		local right = ui.Line { self:motion(), self:permissions(), self:percentage(), self:position() }
 		return {
 			ui.Paragraph(area, { left }),
 			ui.Paragraph(area, { right }):align(ui.Paragraph.RIGHT),
@@ -66,16 +64,16 @@ local render_motion = ya.sync(function(_, motion_num, motion_cmd)
 			motion_span = ui.Span(string.format(" %3d%s ", motion_num, motion_cmd)):style(style)
 		end
 
-		return ui.Line({
+		return ui.Line {
 			ui.Span(THEME.status.separator_open):fg(style.bg),
 			motion_span,
 			ui.Span(THEME.status.separator_close):fg(style.bg),
 			ui.Span(" "),
-		})
+		}
 	end
 end)
 
-local render_numbers = ya.sync(function(state, mode)
+local render_numbers = ya.sync(function(_, mode)
 	ya.render()
 
 	File.number = function(_, index, file, hovered)
@@ -119,7 +117,7 @@ local render_numbers = ya.sync(function(state, mode)
 
 		local items, markers = {}, {}
 		for i, f in ipairs(files) do
-			items[#items + 1] = ui.ListItem(ui.Line(ya.flat({ File:number(i, f, hovered_index), File:full(f) })))
+			items[#items + 1] = ui.ListItem(ui.Line(ya.flat { File:number(i, f, hovered_index), File:full(f) }))
 				:style(File:style(f))
 
 			-- Yanked/marked/selected files
@@ -129,25 +127,21 @@ local render_numbers = ya.sync(function(state, mode)
 			end
 		end
 
-		return ya.flat({
+		return ya.flat {
 			ui.List(area, items),
 			Folder:linemode(area, files),
 			Folder:markers(area, markers),
-		})
+		}
 	end
 end)
 
-local function render_clear()
-	render_motion()
-end
+local function render_clear() render_motion() end
 
 -----------------------------------------------
 --------- C O M M A N D   P A R S E R ---------
 -----------------------------------------------
 
-local get_keys = ya.sync(function(state)
-	return state._only_motions and MOTION_KEYS or MOTIONS_AND_OP_KEYS
-end)
+local get_keys = ya.sync(function(state) return state._only_motions and MOTION_KEYS or MOTIONS_AND_OP_KEYS end)
 
 local function get_cmd(first_char, keys)
 	local last_key
@@ -155,7 +149,7 @@ local function get_cmd(first_char, keys)
 
 	while true do
 		render_motion(tonumber(lines))
-		local key = ya.which({ cands = keys, silent = true })
+		local key = ya.which { cands = keys, silent = true }
 		if not key then
 			return nil, nil, nil
 		end
@@ -176,7 +170,7 @@ local function get_cmd(first_char, keys)
 		DIRECTION_KEYS[#DIRECTION_KEYS + 1] = {
 			on = last_key,
 		}
-		local direction_key = ya.which({ cands = DIRECTION_KEYS, silent = true })
+		local direction_key = ya.which { cands = DIRECTION_KEYS, silent = true }
 		if not direction_key then
 			return nil, nil, nil
 		end

--- a/init.lua
+++ b/init.lua
@@ -83,16 +83,7 @@ local render_numbers = ya.sync(function(state, mode)
 		if mode == SHOW_NUMBERS_RELATIVE then
 			idx = math.abs(hovered - index)
 		elseif mode == SHOW_NUMBERS_ABSOLUTE then
-			-- only calculate the absolute index of the first file, then use it with the offset from the relative index
-			if index == 1 then
-				for i, f in ipairs(Folder:by_kind(Folder.CURRENT).files) do
-					if f.url == file.url then
-						state._absolute_index = i
-						break
-					end
-				end
-			end
-			idx = state._absolute_index + index - 1
+			idx = file.idx
 		else
 			-- if the hovered file, get absolute index
 			if hovered == index then
@@ -269,7 +260,6 @@ return {
 		end
 
 		-- initialize state variables
-		state._absolute_index = 0
 		state._only_motions = args["only_motions"] or false
 
 		if args["show_motion"] then

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,6 @@
+indent_width = 2
+call_parentheses = "NoSingleTable"
+collapse_simple_statement = "FunctionOnly"
+
+[sort_requires]
+enabled = true


### PR DESCRIPTION
Hi, I added a new `idx` property to the `File` type, it should resolve this problem. (Needs the latest main branch of Yazi)

BTW what Lua formatting tool are you using, and could you add its configuration file? My StyLua default configuration is a bit mismatched with it :)