### PR TITLE
add non-integer initial trigger

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -155,7 +155,7 @@ end
 
 local function get_cmd(first_char, keys)
 	local last_key
-	local lines = first_char or ""
+	local lines = first_char ~= "nil" and first_char or ""
 
 	while true do
 		render_motion(tonumber(lines))
@@ -216,9 +216,6 @@ return {
 		-- this is checking if the argument is a valid number
 		if args then
 			initial_value = tostring(tonumber(args[1]))
-			if initial_value == "nil" then
-				return
-			end
 		end
 
 		local lines, cmd, direction = get_cmd(initial_value, get_keys())

--- a/init.lua
+++ b/init.lua
@@ -155,7 +155,7 @@ end
 
 local function get_cmd(first_char, keys)
 	local last_key
-	local lines = first_char ~= "nil" and first_char or ""
+	local lines = first_char or ""
 
 	while true do
 		render_motion(tonumber(lines))
@@ -214,8 +214,11 @@ return {
 		local initial_value
 
 		-- this is checking if the argument is a valid number
-		if args then
+		if #args > 0 then
 			initial_value = tostring(tonumber(args[1]))
+			if initial_value == "nil" then
+				return
+			end
 		end
 
 		local lines, cmd, direction = get_cmd(initial_value, get_keys())


### PR DESCRIPTION
1. Problem (#13)
- relative-motion can operates only with `--args=n` options.
- If someone want to use other character as initial trigger of this plugin without --args, it returns without doing anything

2. Reason
- when this function is calling without `--args` `initial_value` is nil and entry() function returns

3. Solution
- initial_value has "nil" string not real nil when there are no arguments (non-integer argument)
- so In get_cmd(), if the `first_char` is "nil", it makes `first_char` to empty character