### PR TITLE
fix: adapt to new yazi arrow command for pane navigation

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -220,7 +220,7 @@ local get_cache_or_first_dir = ya.sync(function(state)
 	elseif state._enter_mode == ENTER_MODE_CACHE_OR_FIRST then
 		local hovered_file = cx.active.current.hovered
 
-		if  hovered_file ~= nil and hovered_file.cha.is_dir then
+		if hovered_file ~= nil and hovered_file.cha.is_dir then
 			return cx.active.current.cursor
 		end
 	end
@@ -263,7 +263,7 @@ return {
 
 		if cmd == "g" then
 			if direction == "g" then
-				ya.manager_emit("arrow", { -99999999 })
+				ya.manager_emit("arrow", { "top" })
 				ya.manager_emit("arrow", { lines - 1 })
 				render_clear()
 				return
@@ -295,7 +295,7 @@ return {
 				ya.manager_emit("enter", {})
 				local file_idx = get_cache_or_first_dir()
 				if file_idx then
-					ya.manager_emit("arrow", { -99999999 })
+					ya.manager_emit("arrow", { "top" })
 					ya.manager_emit("arrow", { file_idx })
 				end
 			end


### PR DESCRIPTION
Yazi's API has changed, requiring the use of the "arrow top" and "arrow bottom" commands to jump to the top or bottom of the current pane. See the related change here: https://github.com/sxyazi/yazi/pull/2294.

This commit updates the plugin to use the new commands, preventing the popup from appearing when navigating panes in newer Yazi versions. :)