### PR TITLE
more compact number formatting

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -92,7 +92,7 @@ end)
 local render_numbers = ya.sync(function(_, mode)
 	ya.render()
 
-	Entity.number = function(_, index, file, hovered)
+	Entity.number = function(_, index, total, file, hovered)
 		local idx
 		if mode == SHOW_NUMBERS_RELATIVE then
 			idx = math.abs(hovered - index)
@@ -106,13 +106,13 @@ local render_numbers = ya.sync(function(_, mode)
 			end
 		end
 
+        local num_format = "%" .. #tostring(total) .. "d"
+
 		-- emulate vim's hovered offset
-		if idx >= 100 then
-			return ui.Span(string.format("%4d ", idx))
-		elseif hovered == index then
-			return ui.Span(string.format("%3d  ", idx))
+		if hovered == index then
+			return ui.Span(string.format(num_format .. " ", idx))
 		else
-			return ui.Span(string.format(" %3d ", idx))
+			return ui.Span(string.format(" " .. num_format , idx))
 		end
 	end
 
@@ -135,7 +135,7 @@ local render_numbers = ya.sync(function(_, mode)
 			linemodes[#linemodes + 1] = Linemode:new(f):redraw()
 
 			local entity = Entity:new(f)
-			entities[#entities + 1] = ui.Line({ Entity:number(i, f, hovered_index), entity:redraw() }):style(entity:style())
+			entities[#entities + 1] = ui.Line({ Entity:number(i, #self._folder.files, f, hovered_index), entity:redraw() }):style(entity:style())
 		end
 
 		return {


### PR DESCRIPTION
This PR uses the actual file number count to adjust the padding and make the display more compact.

(Previously, this plugin hard-coded 4-digit width regardless of the number of files in the current dir.)

## Before

![image](https://github.com/user-attachments/assets/47aa221f-a868-48a3-9e61-5e12c1c3dbfc)

![image](https://github.com/user-attachments/assets/1727c0ff-2a9e-4c71-9b38-903fc854ee03)

## After

![Screenshot from 2025-03-31 12-48-07](https://github.com/user-attachments/assets/fbce7c5f-4e25-4884-807d-7378197e7b0d)

![image](https://github.com/user-attachments/assets/3a853746-527d-4036-993f-9ef26ea42bde)

